### PR TITLE
Add missing docstrings

### DIFF
--- a/mcda/configuration/config.py
+++ b/mcda/configuration/config.py
@@ -31,7 +31,8 @@ class Config:
 
     Methods:
     __init__(input_config: dict): instantiate a configuration object.
-    _validate(input_config, valid_keys, str_values, int_values, list_values, dict_values): validate the input configuration.
+    _validate(input_config, valid_keys, str_values, int_values, list_values, dict_values): validate the input
+    configuration.
     get_property(property_name: str): retrieve a property from the configuration.
     check_dict_keys(dic: Dict[str, Any], keys: List[str]): check if a specific key is in a dictionary.
     check_key(dic: dict, key: str): check if a key is in a dictionary.

--- a/mcda/configuration/config.py
+++ b/mcda/configuration/config.py
@@ -8,19 +8,33 @@ from typing import List, Dict, Any
 
 
 # noinspection PyMethodMayBeStatic
-class Config():
+class Config:
     """
-    Class Configuration
+    Class representing configuration settings.
 
-    keys expected in the input dictionary are
-    input_matrix_path: path to the input matrix
-    marginal_distribution_for_each indicator: list of marginal distributions, one for each indicator
-    polarity_for_each_indicator: list of polarities, one for each indicator
-    monte_carlo_runs: number of MC runs
-    num_cores: number of cores used in the parallelization
-    monte_carlo_runs: list of weights, one for each indicator
-    output_path: path to the output file
+    This class encapsulates the configuration settings.
+    It expects the following keys in the input dictionary:
+    - input_matrix_path: path to the input matrix file.
+    - polarity_for_each_indicator: list of polarities, one for each indicator.
+    - sensitivity: sensitivity configuration.
+    - robustness: robustness configuration.
+    - monte_carlo_sampling: Monte Carlo sampling configuration.
+    - output_path: path to the output file.
 
+    Attributes:
+    _valid_keys (List[str]): list of valid keys expected in the input dictionary.
+    _list_values (List[str]): list of keys corresponding to list values.
+    _str_values (List[str]): list of keys corresponding to string values.
+    _int_values (List[str]): list of keys corresponding to integer values.
+    _dict_values (List[str]): list of keys corresponding to dictionary values.
+    _keys_of_dict_values (Dict[str, List[str]]): dictionary containing keys and their corresponding sub-keys.
+
+    Methods:
+    __init__(input_config: dict): instantiate a configuration object.
+    _validate(input_config, valid_keys, str_values, int_values, list_values, dict_values): validate the input configuration.
+    get_property(property_name: str): retrieve a property from the configuration.
+    check_dict_keys(dic: Dict[str, Any], keys: List[str]): check if a specific key is in a dictionary.
+    check_key(dic: dict, key: str): check if a key is in a dictionary.
     """
 
     _valid_keys: List[str] = ['input_matrix_path',
@@ -34,7 +48,7 @@ class Config():
         'marginal_distribution_for_each_indicator', 'polarity_for_each_indicator']
 
     _str_values: List[str] = ['input_matrix_path', 'output_path', 'sensitivity_on', 'normalization', 'aggregation',
-                   'robustness_on', 'on_single_weights', 'on_all_weights', 'given_weights', 'on_indicators']
+                              'robustness_on', 'on_single_weights', 'on_all_weights', 'given_weights', 'on_indicators']
 
     _int_values: List[str] = ['monte_carlo_runs', 'num_cores']
 
@@ -47,10 +61,6 @@ class Config():
                                                      'marginal_distribution_for_each_indicator']}
 
     def __init__(self, input_config: dict):
-        """
-        Instantiate a configuration object
-        :param input_config: dictionary
-        """
 
         valid_keys = self._valid_keys
         str_values = self._str_values
@@ -122,13 +132,11 @@ class Config():
 
     @staticmethod
     def check_dict_keys(dic: Dict[str, Any], keys: List[str]):
-        """Check if a specific key is in a dictionary"""
         for key in keys:
             Config.check_key(dic, key)
 
     @staticmethod
     def check_key(dic: dict, key: str):
-        """Check if a key is in a dictionary"""
         if key not in dic.keys():
             raise KeyError(
                 "The key = {} is not present in dictionary: {}".format(key, dic))

--- a/mcda/mcda_functions/aggregation.py
+++ b/mcda/mcda_functions/aggregation.py
@@ -11,17 +11,13 @@ logger = logging.getLogger("ProMCDA")
 
 class Aggregation(object):
     """
-    Class Aggregation
-
-    This class aggregates the normalized values of each indicator
-    by mean of different aggregation functions. The input_matrix contains
-    normalized values of the indicators
+    This class aggregates the normalized values of each indicator by mean of different aggregation functions.
+    The input_matrix contains normalized values of the indicators.
 
     Type of aggregation functions
-    Compensatory: weighted-sum (i.e. additive)
-    Partially compensatory: geometric; harmonic
-    Non-compensatory: minimum
-
+    Compensatory: weighted-sum (i.e. additive).
+    Partially compensatory: geometric; harmonic.
+    Non-compensatory: minimum.
     """
 
     def __init__(self, weights: list):
@@ -32,12 +28,12 @@ class Aggregation(object):
 
     def weighted_sum(self, norm_indicators: pd.DataFrame()) -> pd.Series(dtype='object'):
         """
-        Weighted-sum or additive aggregation function
-        gets as input the normalized values of the indicators in a matrix
-        and estimates the scores over the indicators, per alternative.
+        Weighted-sum or additive aggregation function gets as input the normalized values of the indicators in a matrix
+        and estimates the scores over the indicators, per alternative. The norm_indicators has
+        shape = (no.alternatives x num. indicators) and the returned scores has length = num. of alternatives.
 
-        :gets: pd.DataFrame() of shape (no.alternatives x num. indicators)
-        :returns: pd.Series of length = num. of alternatives
+        :param norm_indicators: pd.DataFrame()
+        :returns scores: pd.Series
         """
 
         scores = (norm_indicators * self.weights).sum(axis=1)
@@ -46,14 +42,14 @@ class Aggregation(object):
 
     def geometric(self, norm_indicators: pd.DataFrame()) -> np.ndarray:
         """
-        The weighted geometric mean works only with strictly positive
-        normalized indicator values (i.e. not with minmax and target with feature range (0,1);
-        not with standardized with feature range ('-inf','+inf')).
-        Gets as input the normalized values of the indicators in a matrix
-        and estimates the scores over the indicators, per alternative.
+        The weighted geometric mean works only with strictly positive normalized indicator values
+        (i.e. not with minmax and target with feature range (0,1); and not with standardized with feature range
+        ('-inf','+inf')). It gets as input positive normalized values of the indicators in a matrix and estimates the
+        scores over the indicators, per alternative. The norm_indicators has shape = (no.alternatives x num. indicators)
+        and the returned scores has length = num. of alternatives.
 
-        :gets: pd.DataFrame() of shape (no.alternatives x num. indicators)
-        :returns: pd.Series of length = num. of alternatives
+        :param norm_indicators: pd.DataFrame()
+        :returns scores: pd.Series
         """
 
         if (norm_indicators <= 0).any().any():
@@ -68,14 +64,14 @@ class Aggregation(object):
 
     def harmonic(self, norm_indicators: pd.DataFrame()) -> np.ndarray:
         """
-        The weighted harmonic mean works only with strictly positive
-        normalized indicator values (i.e. not with minmax, and target with feature range (0,1);
-        not with standardized with feature range ('-inf','+inf')).
-        Gets as input the normalized values of the indicators in a matrix
-        and estimates the scores over the indicators, per alternative.
+        The weighted harmonic mean works only with strictly positive normalized indicator values
+        (i.e. not with minmax, and target with feature range (0,1); and not with standardized with feature range
+        ('-inf','+inf')). It gets as input positive normalized values of the indicators in a matrix and estimates the
+        scores over the indicators, per alternative. The norm_indicators has shape = (no.alternatives x num. indicators)
+        and the returned scores has length = num. of alternatives.
 
-        :gets: pd.DataFrame() of shape (no.alternatives x num. indicators)
-        :returns: pd.Series of length = num. of alternatives
+        :param norm_indicators: pd.DataFrame()
+        :returns scores: pd.Series
         """
 
         if (norm_indicators == 0).any().any():
@@ -87,15 +83,15 @@ class Aggregation(object):
 
         return scores
 
-    # noinspection PyMethodMayBeStatic
     def minimum(self, norm_indicators: pd.DataFrame()) -> pd.Series(dtype='object'):
         """
         Minimum aggregation function. It does not consider the weights.
-        Gets as input the normalized values of the indicators
-        in a matrix and estimates the scores over the indicators, per alternative.
+        It gets as input the normalized values of the indicators in a matrix and estimates the scores over the
+        indicators, per alternative. The norm_indicators has shape = (no.alternatives x num. indicators) and the
+        returned scores has length = num. of alternatives.
 
-        :gets: pd.DataFrame() of shape (no.alternatives x num. indicators)
-        :returns: pd.Series of length = num. of alternatives
+        :param norm_indicators: pd.DataFrame()
+        :returns scores: pd.Series
         """
 
         scores = norm_indicators.min(axis=1)

--- a/mcda/mcda_functions/aggregation.py
+++ b/mcda/mcda_functions/aggregation.py
@@ -30,7 +30,7 @@ class Aggregation(object):
         """
         Weighted-sum or additive aggregation function gets as input the normalized values of the indicators in a matrix
         and estimates the scores over the indicators, per alternative. The norm_indicators has
-        shape = (no.alternatives x num. indicators) and the returned scores has length = num. of alternatives.
+        shape = (num. alternatives x num. indicators) and the returned scores has length = num. of alternatives.
 
         :param norm_indicators: pd.DataFrame
         :returns scores: pd.Series

--- a/mcda/mcda_functions/aggregation.py
+++ b/mcda/mcda_functions/aggregation.py
@@ -26,13 +26,13 @@ class Aggregation(object):
         if sum(self.weights) != 1:
             self.weights = [val / sum(self.weights) for val in self.weights]
 
-    def weighted_sum(self, norm_indicators: pd.DataFrame()) -> pd.Series(dtype='object'):
+    def weighted_sum(self, norm_indicators: pd.DataFrame) -> pd.Series(dtype='object'):
         """
         Weighted-sum or additive aggregation function gets as input the normalized values of the indicators in a matrix
         and estimates the scores over the indicators, per alternative. The norm_indicators has
         shape = (no.alternatives x num. indicators) and the returned scores has length = num. of alternatives.
 
-        :param norm_indicators: pd.DataFrame()
+        :param norm_indicators: pd.DataFrame
         :returns scores: pd.Series
         """
 
@@ -40,7 +40,7 @@ class Aggregation(object):
 
         return scores
 
-    def geometric(self, norm_indicators: pd.DataFrame()) -> np.ndarray:
+    def geometric(self, norm_indicators: pd.DataFrame) -> np.ndarray:
         """
         The weighted geometric mean works only with strictly positive normalized indicator values
         (i.e. not with minmax and target with feature range (0,1); and not with standardized with feature range
@@ -48,10 +48,9 @@ class Aggregation(object):
         scores over the indicators, per alternative. The norm_indicators has shape = (no.alternatives x num. indicators)
         and the returned scores has length = num. of alternatives.
 
-        :param norm_indicators: pd.DataFrame()
+        :param norm_indicators: pd.DataFrame
         :returns scores: pd.Series
         """
-
         if (norm_indicators <= 0).any().any():
             logger.error('Error Message', stack_info=True)
             raise ValueError(
@@ -62,7 +61,7 @@ class Aggregation(object):
 
         return scores
 
-    def harmonic(self, norm_indicators: pd.DataFrame()) -> np.ndarray:
+    def harmonic(self, norm_indicators: pd.DataFrame) -> np.ndarray:
         """
         The weighted harmonic mean works only with strictly positive normalized indicator values
         (i.e. not with minmax, and target with feature range (0,1); and not with standardized with feature range
@@ -70,7 +69,7 @@ class Aggregation(object):
         scores over the indicators, per alternative. The norm_indicators has shape = (no.alternatives x num. indicators)
         and the returned scores has length = num. of alternatives.
 
-        :param norm_indicators: pd.DataFrame()
+        :param norm_indicators: pd.DataFrame
         :returns scores: pd.Series
         """
 
@@ -83,17 +82,16 @@ class Aggregation(object):
 
         return scores
 
-    def minimum(self, norm_indicators: pd.DataFrame()) -> pd.Series(dtype='object'):
+    def minimum(self, norm_indicators: pd.DataFrame) -> pd.Series(dtype='object'):
         """
         Minimum aggregation function. It does not consider the weights.
         It gets as input the normalized values of the indicators in a matrix and estimates the scores over the
         indicators, per alternative. The norm_indicators has shape = (no.alternatives x num. indicators) and the
         returned scores has length = num. of alternatives.
 
-        :param norm_indicators: pd.DataFrame()
+        :param norm_indicators: pd.DataFrame
         :returns scores: pd.Series
         """
-
         scores = norm_indicators.min(axis=1)
 
         return scores

--- a/mcda/mcda_functions/normalization.py
+++ b/mcda/mcda_functions/normalization.py
@@ -6,19 +6,14 @@ from sklearn import preprocessing
 
 class Normalization(object):
     """
-    Class Normalization
-
-    This class normalizes the values of each indicator in the input_matrix
-    by mean of different normalization functions.
-    Each function rescales the values by considering their initial polarity.
-    If the polarity is negative (i.e. the scale is reversed), then the
-    smallest the value the better.
+    This class normalizes the values of each indicator in the input_matrix by mean of different normalization functions.
+    Each function rescales the values by considering their initial polarity. If the polarity is negative (i.e. the scale
+    is reversed), then the smallest the value the better.
 
     Type of normalization functions
-    Ordinal: rank
-    Interval: standardized; min-max
-    Ratio: target
-
+    Ordinal: rank.
+    Interval: standardized; min-max.
+    Ratio: target.
     """
 
     def __init__(self, input_matrix: pd.DataFrame(), polarities: list):
@@ -28,12 +23,7 @@ class Normalization(object):
 
     def _cast_polarities(self) -> tuple[list[int], list[int], pd.DataFrame, pd.DataFrame]:
         """
-        Identifies indicators with positive
-        or negative polarity (by indexes) and
-        cast them into two separate dfs
-
-        :data: input matrix
-        :returns: list of 2 lists for pos and neg indexes, and 2 dfs
+        Identifies indicators with positive or negative polarity (by indexes) and cast them into two separate dfs.
         """
 
         ind_plus = [i for i, e in enumerate(self.polarities) if e == "+"]
@@ -46,12 +36,27 @@ class Normalization(object):
     @staticmethod
     def reversed_minmax_scaler(data, feature_range: tuple):
         """
-        Rescales the indicators in a reversed scale
-        where the smallest the value the better,
-        by using the scaling method min-max.
+        Rescales the indicators in a reversed scale where the smallest the value the better, by using the scaling method
+        min-max. The feature_range defines if the feature range is (0,1) or (0.1,1).
 
-        :param: range defines if the feature range is (0,1) or (0.1,1)
-        :returns: numpy array
+        Example:
+        ```python
+        data = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        feature_range = (0, 1)
+        scaled_data = reversed_minmax_scaler(data, feature_range)
+        ```
+        This will rescale the input data using the reversed min-max scaling method with the specified feature range:
+
+        ```
+        scaled_data:
+        [[1.  0.  0. ]
+        [0.5 0.5 0.5]
+        [0.  1.  1. ]]
+        ```
+
+        :param data: pd.DataFrame()
+        :param feature_range: tuple
+        :returns scaled_data: np.array
         """
 
         data = np.array(data)
@@ -69,9 +74,27 @@ class Normalization(object):
 
     def minmax(self, feature_range: tuple) -> pd.DataFrame():
         """
-        Normalizes the indicators by using the scaling method min-max.
-        Different feature ranges are possible.
-        :returns: pd.DataFrame() of same shape as the input
+        Normalizes the indicators by using the scaling method min-max. Different feature ranges are possible.
+        The returned indicators_scaled_minmax is of same shape as the input data.
+
+        Example:
+        ```python
+        input_data = pd.DataFrame([[10, 20, 30], [40, 50, 60], [70, 80, 90]])
+        normalization_instance = Normalization(input_data)
+        feature_range = (0, 1)
+        normalized_data = normalization_instance.minmax(feature_range)
+        ```
+        This will normalize the input data using the min-max scaling method with the specified feature range:
+
+        ```
+        min-max normalized_data:
+           0    1    2
+        0  0.0  0.0  0.0
+        1  0.5  0.5  0.5
+        2  1.0  1.0  1.0
+        ```
+
+        :return indicators_scaled_minmax: pd.DataFrame()
         """
 
         original_shape = self._input_matrix.shape
@@ -108,8 +131,27 @@ class Normalization(object):
 
     def target(self, feature_range: tuple) -> pd.DataFrame():
         """
-        Normalizes indicators using the scaling method target.
-        :return: pd.DataFrame() of same shape as the input
+        Normalizes the indicators using the scaling method target.
+        The returned indicators_scaled_target is of same shape as the input data.
+
+        Example:
+        ```python
+        input_data = pd.DataFrame([[10, 20, 30], [40, 50, 60], [70, 80, 90]])
+        normalization_instance = Normalization(input_data)
+        feature_range = (0, 1)
+        normalized_data = normalization_instance.target(feature_range)
+        ```
+        This will normalize the input data using the target scaling method with the specified feature range:
+
+        ```
+        target normalized_data:
+           0     1     2
+        0  0.14  0.25  0.33
+        1  0.57  0.52  0.66
+        2  1.0   1.0    1.0
+        ```
+
+        :return indicators_scaled_target: pd.DataFrame()
         """
 
         original_shape = self._input_matrix.shape
@@ -145,8 +187,27 @@ class Normalization(object):
 
     def standardized(self, feature_range: tuple) -> pd.DataFrame():
         """
-        Normalizes indicators using the scaling method standardized (i.e. Z-score).
-        :return: pd.DataFrame() of same shape as the input
+        Normalizes the indicators using the scaling method standardized (i.e. Z-score).
+        The returned indicators_scaled_standardized is of same shape as the input data.
+
+        Example:
+        ```python
+        input_data = pd.DataFrame([[10, 20, 30], [40, 50, 60], [70, 80, 90]])
+        normalization_instance = Normalization(input_data)
+        feature_range = (0, 1)
+        normalized_data = normalization_instance.standardized(feature_range)
+        ```
+        This will normalize the input data using the standardized scaling method with the specified feature range:
+
+        ```
+        Z-score normalized_data:
+           0     1     2
+        0 -1.22 -1.22 -1.22
+        1  0.00  0.00  0.00
+        2  1.22  1.22  1.22
+        ```
+
+        :return indicators_scaled_standardized: pd.DataFrame()
         """
 
         original_shape = self._input_matrix.shape
@@ -183,7 +244,26 @@ class Normalization(object):
     def rank(self) -> pd.DataFrame():
         """
         Normalizes indicators using the scaling method rank.
-        :return: pd.DataFrame() of same shape as the input
+        The returned indicators_scaled_rank is of same shape as the input data.
+
+        Example:
+        ```python
+        input_data = pd.DataFrame([[10, 20, 30], [40, 50, 60], [70, 80, 90]])
+        normalization_instance = Normalization(input_data)
+        feature_range = (0, 1)
+        normalized_data = normalization_instance.rank(feature_range)
+        ```
+        This will normalize the input data using the rank scaling method with the specified feature range:
+
+        ```
+        rank normalized_data:
+            0  1  2
+        0  -1  2  3
+        1   4  5  6
+        2   7  8  9
+        ```
+
+        :return indicators_scaled_rank: pd.DataFrame()
         """
         original_shape = self._input_matrix.shape
 

--- a/mcda/mcda_functions/normalization.py
+++ b/mcda/mcda_functions/normalization.py
@@ -16,7 +16,7 @@ class Normalization(object):
     Ratio: target.
     """
 
-    def __init__(self, input_matrix: pd.DataFrame(), polarities: list):
+    def __init__(self, input_matrix: pd.DataFrame, polarities: list):
 
         self._input_matrix = copy.deepcopy(input_matrix)
         self.polarities = polarities
@@ -25,7 +25,6 @@ class Normalization(object):
         """
         Identifies indicators with positive or negative polarity (by indexes) and cast them into two separate dfs.
         """
-
         ind_plus = [i for i, e in enumerate(self.polarities) if e == "+"]
         ind_minus = [i for i, e in enumerate(self.polarities) if e == "-"]
         indicators_plus = self._input_matrix.iloc[:, ind_plus]
@@ -54,11 +53,10 @@ class Normalization(object):
         [0.  1.  1. ]]
         ```
 
-        :param data: pd.DataFrame()
+        :param data: pd.DataFrame
         :param feature_range: tuple
         :returns scaled_data: np.array
         """
-
         data = np.array(data)
 
         max_val = np.max(data, axis=0)
@@ -72,7 +70,7 @@ class Normalization(object):
 
         return scaled_data
 
-    def minmax(self, feature_range: tuple) -> pd.DataFrame():
+    def minmax(self, feature_range: tuple) -> pd.DataFrame:
         """
         Normalizes the indicators by using the scaling method min-max. Different feature ranges are possible.
         The returned indicators_scaled_minmax is of same shape as the input data.
@@ -94,9 +92,8 @@ class Normalization(object):
         2  1.0  1.0  1.0
         ```
 
-        :return indicators_scaled_minmax: pd.DataFrame()
+        :return indicators_scaled_minmax: pd.DataFrame
         """
-
         original_shape = self._input_matrix.shape
 
         pol = Normalization._cast_polarities(self)
@@ -129,7 +126,7 @@ class Normalization(object):
 
         return indicators_scaled_minmax
 
-    def target(self, feature_range: tuple) -> pd.DataFrame():
+    def target(self, feature_range: tuple) -> pd.DataFrame:
         """
         Normalizes the indicators using the scaling method target.
         The returned indicators_scaled_target is of same shape as the input data.
@@ -151,9 +148,8 @@ class Normalization(object):
         2  1.0   1.0    1.0
         ```
 
-        :return indicators_scaled_target: pd.DataFrame()
+        :return indicators_scaled_target: pd.DataFrame
         """
-
         original_shape = self._input_matrix.shape
 
         pol = Normalization._cast_polarities(self)
@@ -185,7 +181,7 @@ class Normalization(object):
 
         return indicators_scaled_target
 
-    def standardized(self, feature_range: tuple) -> pd.DataFrame():
+    def standardized(self, feature_range: tuple) -> pd.DataFrame:
         """
         Normalizes the indicators using the scaling method standardized (i.e. Z-score).
         The returned indicators_scaled_standardized is of same shape as the input data.
@@ -207,9 +203,8 @@ class Normalization(object):
         2  1.22  1.22  1.22
         ```
 
-        :return indicators_scaled_standardized: pd.DataFrame()
+        :return indicators_scaled_standardized: pd.DataFrame
         """
-
         original_shape = self._input_matrix.shape
 
         pol = Normalization._cast_polarities(self)
@@ -241,7 +236,7 @@ class Normalization(object):
 
         return indicators_scaled_standardized
 
-    def rank(self) -> pd.DataFrame():
+    def rank(self) -> pd.DataFrame:
         """
         Normalizes indicators using the scaling method rank.
         The returned indicators_scaled_rank is of same shape as the input data.
@@ -263,7 +258,7 @@ class Normalization(object):
         2   7  8  9
         ```
 
-        :return indicators_scaled_rank: pd.DataFrame()
+        :return indicators_scaled_rank: pd.DataFrame
         """
         original_shape = self._input_matrix.shape
 

--- a/mcda/mcda_run.py
+++ b/mcda/mcda_run.py
@@ -40,10 +40,9 @@ def main(input_config: dict):
     Note: Ensure that the input matrix, weights, polarities and indicators (with or without uncertainty)
     are correctly specified in the input configuration.
 
-    :return: None
     :param input_config: dict
+    :return: None
     """
-
     is_sensitivity = None
     is_robustness = None
     is_robustness_indicators = 0

--- a/mcda/mcda_with_robustness.py
+++ b/mcda/mcda_with_robustness.py
@@ -17,7 +17,6 @@ logger = logging.getLogger("MCDA with sensitivity")
 
 class MCDAWithRobustness:
     """
-
     Class MCDA with indicators' uncertainty
 
     This class allows one to run MCDA by considering the uncertainties related to the indicators.
@@ -29,7 +28,7 @@ class MCDAWithRobustness:
 
     """
 
-    def __init__(self, config: Config, input_matrix: pd.DataFrame(), is_exact_pdf_mask=None, is_poisson_pdf_mask=None):
+    def __init__(self, config: Config, input_matrix: pd.DataFrame, is_exact_pdf_mask=None, is_poisson_pdf_mask=None):
         self.is_exact_pdf_mask = is_exact_pdf_mask
         self.is_poisson_pdf_mask = is_poisson_pdf_mask
         self._config = copy.deepcopy(config)
@@ -67,20 +66,35 @@ class MCDAWithRobustness:
 
     def create_n_randomly_sampled_matrices(self) -> List[pd.DataFrame]:
         """
-        This function receives an input matrix of dimensions (AxnI).
-        nI = (num. indicators associated with an exact or Poisson PDF) + (2 x num. indicators associated with all others PDF)
-        The columns of the input matrix represent parameter 1 for exact and Poisson; or parameter1 and parameter 2 for the rest.
-        In a first step, the function produces a list of length I of matrices of dimension (AxN).
-        Every matrix represents the N random samples of every alternative (A), per indicator (I).
-        If there are negative random samples, they are rescaled into [0-1].
-        In a second step, a utility function converts this list into a list of length N of matrices of dimension (AxI).
-        The output is therefore a list containing N randomly sampled input matrices. The PDFs from where random values
-        are sampled depends on the indicator marginal distributions.
+        Generate N random samples for each indicator in the input matrix based on their marginal distributions.
 
-        A: all alternatives
-        I: all indicators
-        nI: all indicators first and second parameters, if the second is needed
-        N: number of random samples
+        This function takes an input matrix of dimensions (A x nI), where:
+        - A represents the number of all alternatives,
+        - nI is the total number of indicator parameters (including first and second parameters),
+        - the columns of the input matrix represent respectively only parameter 1 for exact and Poisson distributions,
+          or parameter 1 and parameter 2 for other distributions.
+
+        The function first produces a list of length I, where each element is a matrix of dimensions (A x N).
+        Each matrix represents N random samples for every alternative (A) for a specific indicator (I).
+        If any of the random samples are negative, they are rescaled to fall within the [0, 1] range.
+
+        Then, the function converts this list into a list of length N, where each element is a matrix of dimensions (A x I).
+        The output is a list containing N randomly sampled input matrices, with the PDFs from which random values are sampled
+        determined by the indicator marginal distributions.
+
+        Parameters:
+        - None
+
+        Returns:
+        - list: A list containing N randomly sampled input matrices.
+
+        Notes:
+        - 'A' represents the number of all alternatives.
+        - 'I' represents the number of all indicators.
+        - 'nI' represents the total number of indicator parameters.
+        - 'N' represents the number of random samples.
+
+        :return list_random_matrix: List[pd.DataFrame]
         """
         marginal_pdf = self._config.monte_carlo_sampling["marginal_distribution_for_each_indicator"]
         num_runs = self._config.monte_carlo_sampling["monte_carlo_runs"]  # N

--- a/mcda/mcda_without_robustness.py
+++ b/mcda/mcda_without_robustness.py
@@ -88,7 +88,8 @@ class MCDAWithoutRobustness:
         Aggregate the normalized indicators using the specified aggregation method.
 
         Parameters:
-        - normalized_indicators: a dictionary containing the normalized values of each indicator per normalization method.
+        - normalized_indicators: a dictionary containing the normalized values of each indicator per normalization
+          method.
         - weights: the weights to be applied during aggregation.
         - method (optional): The aggregation method to use. If None, all available methods will be applied.
         Supported methods: 'weighted_sum', 'geometric', 'harmonic', 'minimum'.
@@ -114,9 +115,10 @@ class MCDAWithoutRobustness:
         scores = pd.DataFrame()
         col_names_method = []
         col_names = ['ws-minmax_01', 'ws-target_01', 'ws-standardized_any', 'ws-rank',
-                     'geom-minmax_without_zero', 'geom-target_without_zero', 'geom-standardized_without_zero', 'geom-rank',
-                     'harm-minmax_without_zero', 'harm-target_without_zero', 'harm-standardized_without_zero', 'harm-rank',
-                     'min-standardized_any']  # same order as in the following loop
+                     'geom-minmax_without_zero', 'geom-target_without_zero', 'geom-standardized_without_zero',
+                     'geom-rank', 'harm-minmax_without_zero', 'harm-target_without_zero',
+                     'harm-standardized_without_zero', 'harm-rank', 'min-standardized_any']
+        # column names has the same order as in the following loop
 
         for key, values in self.normalized_indicators.items():
             if method is None or method == 'weighted_sum':

--- a/mcda/mcda_without_robustness.py
+++ b/mcda/mcda_without_robustness.py
@@ -19,16 +19,11 @@ class MCDAWithoutRobustness:
     Class MCDA without indicators' uncertainty
 
     This class allows one to run MCDA without considering the uncertainties related to the indicators.
-    All indicators are associated to the exact type of marginal distribution.
+    All indicators are described by the exact marginal distribution.
     However, it's possible to have randomly sampled weights.
-
-    :input:  configuration dictionary
-             input_matrix with no alternatives column
-    :output: write csv files with the scores, normalized scores and ranks; log file
-
     """
 
-    def __init__(self, config: Config, input_matrix: pd.DataFrame()):
+    def __init__(self, config: Config, input_matrix: pd.DataFrame):
         self.normalized_indicators = None
         self.weights = None
         self._config = copy.deepcopy(config)
@@ -36,10 +31,23 @@ class MCDAWithoutRobustness:
 
     def normalize_indicators(self, method=None) -> dict:
         """
-        Get the input matrix.
-        :param method: The normalization method to use (None for all methods).
-        :return: a dictionary that contains the normalized values of each indicator per normalization method.
-        Normalization functions implemented: minmax; target; standardized; rank
+        Normalize the input matrix using the specified normalization method.
+
+        Parameters:
+        - method (optional): the normalization method to use. If None, all available methods will be applied.
+          Supported methods: 'minmax', 'target', 'standardized', 'rank'.
+
+        Returns:
+        - a dictionary containing the normalized values of each indicator per normalization method.
+
+        Notes:
+        Some aggregation methods do not work with indicator values equal or smaller than zero. For that reason:
+        - for the 'minmax' method, two sets of normalized indicators are returned: one with the range (0, 1) and
+          another with the range (0.1, 1).
+        - for the 'target' method, two sets of normalized indicators are returned: one with the range (0, 1) and
+          another with the range (0.1, 1).
+        - for the 'standardized' method, two sets of normalized indicators are returned: one with the range (-inf, +inf)
+          and another with the range (0.1, +inf).
         """
         norm = Normalization(self._input_matrix,
                              self._config.polarity_for_each_indicator)
@@ -75,14 +83,24 @@ class MCDAWithoutRobustness:
 
         return normalized_indicators
 
-    def aggregate_indicators(self, normalized_indicators: dict, weights: list, method=None) -> pd.DataFrame():
-        #     """
-        #     Get the normalized indicators per normalization methods in a dictionary.
-        #     :param: method The normalization method to use (None for all methods).
-        #     :return: aggregated scores per each alternative, and per each normalization method.
-        #     Aggregation functions implemented: weighted-sum; geometric; harmonic; minimum
-        #     """
+    def aggregate_indicators(self, normalized_indicators: dict, weights: list, method=None) -> pd.DataFrame:
+        """
+        Aggregate the normalized indicators using the specified aggregation method.
 
+        Parameters:
+        - normalized_indicators: a dictionary containing the normalized values of each indicator per normalization method.
+        - weights: the weights to be applied during aggregation.
+        - method (optional): The aggregation method to use. If None, all available methods will be applied.
+        Supported methods: 'weighted_sum', 'geometric', 'harmonic', 'minimum'.
+
+        Returns:
+        - a DataFrame containing the aggregated scores per each alternative, and per each normalization method.
+
+        :param normalized_indicators: dict
+        :param weights: list
+        :param method: str
+        :return scores: pd.DataFrame
+        """
         self.normalized_indicators = normalized_indicators
         self.weights = weights
 
@@ -93,7 +111,7 @@ class MCDAWithoutRobustness:
         scores_harmonic = {}
         scores_minimum = {}
 
-        scores = pd.DataFrame()
+        scores = pd.DataFrame
         col_names_method = []
         col_names = ['ws-minmax_01', 'ws-target_01', 'ws-standardized_any', 'ws-rank',
                      'geom-minmax_without_zero', 'geom-target_without_zero', 'geom-standardized_without_zero', 'geom-rank',

--- a/mcda/mcda_without_robustness.py
+++ b/mcda/mcda_without_robustness.py
@@ -111,7 +111,7 @@ class MCDAWithoutRobustness:
         scores_harmonic = {}
         scores_minimum = {}
 
-        scores = pd.DataFrame
+        scores = pd.DataFrame()
         col_names_method = []
         col_names = ['ws-minmax_01', 'ws-target_01', 'ws-standardized_any', 'ws-rank',
                      'geom-minmax_without_zero', 'geom-target_without_zero', 'geom-standardized_without_zero', 'geom-rank',

--- a/mcda/utils/utils_for_main.py
+++ b/mcda/utils/utils_for_main.py
@@ -45,9 +45,7 @@ def check_config_error(condition: bool, error_message: str):
         raise ValueError(error_message)
 
 
-def check_config_setting(condition_robustness_on_weights: bool,
-                         condition_robustness_on_indicators: bool,
-                         mc_runs: int) \
+def check_config_setting(condition_robustness_on_weights: bool, condition_robustness_on_indicators: bool, mc_runs: int)\
         -> (int, int):
     """
     Checks configuration settings and logs information messages.
@@ -552,7 +550,7 @@ def randomly_sample_all_weights(num_weights: int, num_runs: int) -> List[list]:
     This will generate 10 lists, each containing 5 randomly sampled weights.
 
     :param num_weights: int
-    :param num_runs:
+    :param num_runs: int
     :return list_of_weights: List[list]
     """
 

--- a/mcda/utils/utils_for_main.py
+++ b/mcda/utils/utils_for_main.py
@@ -35,9 +35,9 @@ def check_config_error(condition: bool, error_message: str):
     Raises:
     - ValueError: If the condition is True, with the specified error message.
 
-    :return: None
     :param error_message: str
     :param condition: bool
+    :return: None
     """
 
     if condition:
@@ -47,24 +47,20 @@ def check_config_error(condition: bool, error_message: str):
 
 def check_config_setting(condition_robustness_on_weights: bool,
                          condition_robustness_on_indicators: bool,
-                         mc_runs: int) -> (int, int):
+                         mc_runs: int) \
+        -> (int, int):
     """
-        Checks configuration settings and logs information messages.
+    Checks configuration settings and logs information messages.
 
-        Parameters:
-        - condition (bool): The condition to check.
+    Return:
+    - is_robustness_weights, is_robustness_indicators, a tuple containing flags indicating robustness on weights and
+    indicators.
 
-        Returns:
-        :rtype: Tuple[int, int]
-        :return: is_robustness_weights, is_robustness_indicators, a tuple containing flags indicating robustness
-                 on weights and indicators.
+    :param condition_robustness_on_weights: bool
+    :param condition_robustness_on_indicators: bool
+    :rtype: Tuple[int, int]
 
-        Example:
-        ```python
-        is_robustness_weights, is_robustness_indicators = check_config_setting(True, "False,
-                                                                               "True", "False", 1000)
-        ```
-        """
+    """
 
     is_robustness_weights = 0
     is_robustness_indicators = 0
@@ -84,21 +80,20 @@ def check_config_setting(condition_robustness_on_weights: bool,
 
 def process_indicators_and_weights(config: dict, input_matrix: pd.DataFrame,
                                    is_robustness_indicators: int, is_robustness_weights: int, polar: List[str],
-                                   mc_runs: int, num_indicators: int) -> Tuple[
-    List[str], Union[list, List[list], dict]]:
+                                   mc_runs: int, num_indicators: int) \
+        -> Tuple[List[str], Union[list, List[list], dict]]:
     """
     Process indicators and weights based on input parameters in the configuration.
 
     Parameters:
-    - input_matrix (DataFrame): The input matrix without alternatives.
-    - is_robustness_indicators (int): Flag indicating whether the matrix should include indicator uncertainties
-      (0 or 1).
-    - is_robustness_weights (int): Flag indicating whether robustness analysis is considered for the weights
-      (0 or 1).
-    - marginal_pdf (list): List of marginal probability density functions for indicators.
-    - mc_runs (int): Number of Monte Carlo runs for robustness analysis.
-    - num_indicators: the number of indicators in the input matrix.
     - config: the configuration dictionary.
+    - input_matrix: the input matrix without alternatives.
+    - is_robustness_indicators: a flag indicating whether the matrix should include indicator uncertainties
+      (0 or 1).
+    - is_robustness_weights: a flag indicating whether robustness analysis is considered for the weights (0 or 1).
+    - marginal_pdf: a list of marginal probability density functions for indicators.
+    - mc_runs: number of Monte Carlo runs for robustness analysis.
+    - num_indicators: the number of indicators in the input matrix.
 
     Raises:
     - ValueError: If there are duplicated rows in the input matrix or if there is an issue with the configuration.
@@ -125,8 +120,6 @@ def process_indicators_and_weights(config: dict, input_matrix: pd.DataFrame,
     - Performs robustness analysis on weights.
     - Logs randomly sampled weights.
 
-    :return: polar, norm_weights
-    :rtype: Tuple[List[str], Union[List[list], dict]]
     :param mc_runs: int
     :param polar: List[str]
     :param is_robustness_weights: int
@@ -134,6 +127,8 @@ def process_indicators_and_weights(config: dict, input_matrix: pd.DataFrame,
     :param input_matrix: pd.DataFrame
     :param config: dict
     :param num_indicators: int
+    :return: polar, norm_weights
+    :rtype: Tuple[List[str], Union[List[list], dict]]
     """
 
     num_unique = input_matrix.nunique()
@@ -230,7 +225,7 @@ def _handle_robustness_weights(config: dict, mc_runs: int, num_indicators: int) 
 def _handle_no_robustness_indicators(input_matrix: pd.DataFrame):
     """
     Handle the indicators in case of no robustness analysis required.
-    (The input matrix is without the Alternatives)
+    (The input matrix is without the alternative column)
     """
     num_unique = input_matrix.nunique()
     cols_to_drop = num_unique[num_unique == 1].index
@@ -247,7 +242,7 @@ def _handle_no_robustness_indicators(input_matrix: pd.DataFrame):
 def check_indicator_weights_polarities(num_indicators: int, polar: List[str], config: dict):
     """
     Check the consistency of indicators, polarities, and fixed weights in a configuration.
-        
+
     Parameters:
     - num_indicators: the number of indicators in the input matrix.
     - polar: a list containing the polarity associated to each indicator.
@@ -259,12 +254,12 @@ def check_indicator_weights_polarities(num_indicators: int, polar: List[str], co
         does not correspond to the number of indicators.
 
     Raises:
-    - ValueError: If the conditions for indicator-polarity and fixed weights consistency are not met.
-        
-    :return: None
+    - ValueError: if the conditions for indicator-polarity and fixed weights consistency are not met.
+
     :param num_indicators: int
     :param polar: List[str]
     :param config: dict
+    :return: None
     """
 
     if num_indicators != len(polar):
@@ -279,18 +274,18 @@ def check_indicator_weights_polarities(num_indicators: int, polar: List[str], co
 def check_input_matrix(input_matrix: pd.DataFrame) -> pd.DataFrame:
     """
     Check the input matrix for duplicated rows in the alternatives column, rescale negative indicator values
-    and drop the index column 'Alternatives'.
+    and drop the index column of alternatives.
 
     Parameters:
-    - input_matrix: The input matrix containing the alternatives (as index column) and indicators.
+    - input_matrix: The input matrix containing the alternatives and indicators.
 
     Raises:
     - ValueError: If duplicated rows are found in the alternative column.
     - UserStoppedInfo: If the user chooses to stop when duplicates are found.
 
+     :param input_matrix: pd.DataFrame
      :rtype: pd.DataFrame
      :return: input_matrix
-     :param input_matrix: pd.DataFrame
     """
     if input_matrix.duplicated().any():
         raise ValueError('Error: Duplicated rows in the alternatives column.')
@@ -313,13 +308,13 @@ def read_matrix(input_matrix_path: str) -> pd.DataFrame():
     Set the 'Alternatives' column as index column.
 
     Parameters:
-    - input_matrix_path (str): Path to the CSV file containing the input matrix.
+    - input_matrix_path (str): path to the CSV file containing the input matrix.
 
     Raises:
     - Exception: If an error occurs during the file reading or DataFrame creation.
 
-    :rtype: pd.DataFrame
     :param input_matrix_path: str
+    :rtype: pd.DataFrame
     """
 
     try:
@@ -345,8 +340,8 @@ def reset_index_if_needed(series):
     Returns:
     - pd.Series: The series with the index reset if needed.
 
-    # Usage example:
-    res = reset_index_if_needed(res)
+    :param series: pd.Series
+    :return series: pd.Series
     """
     if not isinstance(series.index, pd.RangeIndex):
         series = series.reset_index(drop=True)
@@ -354,7 +349,9 @@ def reset_index_if_needed(series):
 
 
 def _check_and_rescale_negative_indicators(input_matrix: pd.DataFrame) -> pd.DataFrame():
-    """If some indicators in the input matrix are negative, they are rescaled into [0-1]"""
+    """
+    Rescale indicators of the input matrix if negative into [0-1].
+    """
 
     if (input_matrix < 0).any().any():
         scaler = MinMaxScaler()
@@ -390,8 +387,8 @@ def get_config(config_path: str) -> dict:
     Raises:
     - Exception: If an error occurs during file reading or JSON decoding.
 
-    :rtype: dict
     :param config_path: str
+    :rtype: dict
     """
 
     try:
@@ -418,10 +415,10 @@ def save_df(df: pd.DataFrame, folder_path: str, filename: str):
     save_df(my_dataframe, '/path/to/folder', 'data.csv')
     ```
 
-    :return: None
     :param df: pd.DataFrame
     :param folder_path: str
     :param filename: str
+    :return: None
     """
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     new_filename = f"{timestamp}_{filename}"
@@ -444,10 +441,10 @@ def save_dict(dictionary: dict, folder_path: str, filename: str):
     save_dict(my_dict, '/path/to/folder', 'data.pkl')
     ```
 
-    :return: None
     :param dictionary: dict
     :param folder_path: str
     :param filename: str
+    :return: None
     """
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     new_filename = f"{timestamp}_{filename}"
@@ -470,10 +467,11 @@ def save_config(config: dict, folder_path: str, filename: str):
     ```python
     save_config(my_config, '/path/to/folder', 'config.json')
     ```
-    :return: None
+
     :param config: dict
     :param folder_path: str
     :param filename: str
+    :return: None
     """
 
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -492,8 +490,9 @@ def check_path_exists(path: str):
     ```python
     check_path_exists('/path/to/directory')
     ```
-    :return: None
+
     :param path: str
+    :return: None
     """
     is_exist = os.path.exists(path)
     if not is_exist:
@@ -503,19 +502,28 @@ def check_path_exists(path: str):
 
 def rescale_minmax(scores: pd.DataFrame) -> pd.DataFrame():
     """
-    Rescale the values in a DataFrame to a [0, 1] range using Min-Max scaling.
+    Rescale the values in a DataFrame to a [0,1] range using Min-Max scaling.
 
     Parameters:
     - scores (pd.DataFrame): The DataFrame containing numerical values to be rescaled.
 
     Example:
     ```python
+    my_dataframe = pd.DataFrame({
+    'A': [10, 40, 70],
+    'B': [20, 50, 80],
+    'C': [30, 60, 90]
+     })
     rescaled_df = rescale_minmax(my_dataframe)
-    ```
-    This will rescale the values in the input DataFrame to a [0, 1] range.
 
+    rescaled_df:
+         A    B    C
+    0   0.0  0.0  0.0
+    1   0.5  0.5  0.5
+    2   1.0  1.0  1.0
+    ```
+    :param scores: pd.DataFrame()
     :rtype: pd.DataFrame()
-    :param scores: pd.DataFrame
     """
     x = scores.to_numpy()
     min_max_scaler = preprocessing.MinMaxScaler()
@@ -531,8 +539,8 @@ def randomly_sample_all_weights(num_weights: int, num_runs: int) -> List[list]:
     Generate multiple lists of random weights for simulations.
 
     Parameters:
-    - num_weights (int): The number of weights in each list.
-    - num_runs (int): The number of lists to be generated.
+    - num_weights: the number of weights in each list.
+    - num_runs: the number of lists to be generated.
 
     Returns:
     - List[list]: A list containing 'num_runs' lists, each with 'num_weights' randomly sampled elements.
@@ -543,9 +551,9 @@ def randomly_sample_all_weights(num_weights: int, num_runs: int) -> List[list]:
     ```
     This will generate 10 lists, each containing 5 randomly sampled weights.
 
-    :param num_runs:
-    :rtype: List[list]
     :param num_weights: int
+    :param num_runs:
+    :return list_of_weights: List[list]
     """
 
     list_of_weights = []
@@ -561,12 +569,12 @@ def randomly_sample_ix_weight(num_weights: int, index: int, num_runs: int) -> Li
     Generate multiple lists of weights with one randomly sampled element at a specified index.
 
     Parameters:
-    - num_weights (int): The total number of weights in each list.
-    - index (int): The index at which a weight will be randomly sampled in each list.
-    - num_runs (int): The number of lists to be generated.
+    - num_weights: the total number of weights in each list.
+    - index: the index at which a weight will be randomly sampled in each list.
+    - num_runs: the number of lists to be generated.
 
     Returns:
-    - List[list]: A list containing 'num_runs' lists, each with 'num_weights' elements
+    - a list containing 'num_runs' lists, each with 'num_weights' elements
       and one randomly sampled at the specified index.
 
     Example:
@@ -575,10 +583,10 @@ def randomly_sample_ix_weight(num_weights: int, index: int, num_runs: int) -> Li
     ```
     This will generate 10 lists, each containing 5 weights, with one randomly sampled at index 2.
 
-    :rtype: List[list]
     :param num_weights: int
     :param index: int
     :param num_runs: int
+    :return list_of_weights: List[list]
     """
 
     list_of_weights = []
@@ -595,15 +603,10 @@ def check_norm_sum_weights(weights: list) -> list:
     Check if the sum of weights is equal to 1, and normalize the weights if needed.
 
     Returns:
-    - list: The original weights if the sum is already 1, or normalized weights if the sum is not 1.
+    - list: the original weights if the sum is already 1, or normalized weights if the sum is not 1.
 
-    Example:
-    ```python
-    normalized_weights = check_norm_sum_weights([0.2, 0.3, 0.5])
-    ```
-
-    :rtype: list
     :param weights: list
+    :return weights: list
     """
 
     if sum(weights) != 1:
@@ -618,8 +621,8 @@ def pop_indexed_elements(indexes: np.ndarray, original_list: list) -> list:
     Eliminate elements from a list at specified indexes.
 
     Parameters:
-    - indexes (np.ndarray): An array of indexes indicating elements to be removed.
-    - original_list (list): The original list from which elements will be removed.
+    - indexes: an array of indexes indicating elements to be removed.
+    - original_list: the original list from which elements will be removed.
 
     Example:
     ```python
@@ -627,9 +630,9 @@ def pop_indexed_elements(indexes: np.ndarray, original_list: list) -> list:
     ```
     This will remove elements at indexes 1 and 3 from the original list and return the new list [10, 30, 50].
 
-    :rtype: list
     :param indexes: np.ndarray
     :param original_list: list
+    :return new_list: list
     """
     for i in range(len(indexes)):
         index = indexes[i]
@@ -651,30 +654,21 @@ def check_parameters_pdf(input_matrix: pd.DataFrame, config: dict, for_testing=F
     (or vice-versa for the uniform PDF) in case of an input matrix with uncertainties.
     The check runs only in the case of indicators with a PDF of the type normal/lognormal, and uniform.
     In the first case, the parameters represent the (log)mean and (log)std;
-    in the second case, they represent min and max values.
+    in the second case, they represent the min and max values.
 
     Parameters:
-    - input_matrix (pd.DataFrame): The input matrix containing uncertainties for indicators, no alternatives.
-    - config (dict): Configuration dictionary containing the Monte Carlo sampling information.
-    - for_testing (bool): True only for unit testing
+    - input_matrix: the input matrix containing uncertainties for indicators, no alternatives.
+    - config: configuration dictionary containing the Monte Carlo sampling information.
+    - for_testing: true only for unit testing
 
     Returns:
-    - List[bool]: A list indicating whether the conditions are satisfied for each indicator only for testing.
+    - List: a list indicating whether the conditions are satisfied for each indicator (only for unit tests).
     - None: default
 
-    Example:
-    ```python
-    check_parameters_pdf(my_input_matrix, my_config)
-    ```
-
-    This will check conditions on parameters based on the PDF type
-    for each indicator in the input matrix as described above.
-    The result is a list of boolean values indicating whether the conditions are satisfied for each indicator.
-
-    :return: Union[list, None]
     :param input_matrix: pd.DataFrame
     :param config: dict
     :param for_testing: bool
+    :return: Union[list, None]
     """
     config = Config(config)
 
@@ -730,10 +724,10 @@ def check_if_pdf_is_exact(marginal_pdf: list) -> list:
     Check if each indicator's probability distribution function (PDF) is of type 'exact'.
 
     Parameters:
-    - marginal_pdf (list): A list containing the type of PDF for each indicator.
+    - marginal_pdf: a list containing the type of PDF for each indicator.
 
     Returns:
-    - list: A binary mask indicating whether the PDF for each indicator is 'exact' (1) or not (0).
+    - list: a binary mask indicating whether the PDF for each indicator is 'exact' (1) or not (0).
 
     Example:
     ```python
@@ -741,8 +735,8 @@ def check_if_pdf_is_exact(marginal_pdf: list) -> list:
     ```
     This will return a list [1, 0, 1, 0], indicating that the first and third indicators have 'exact' PDFs.
 
-    :rtype: list
     :param marginal_pdf: list
+    :return exact_pdf_mask: List[int]
     """
     exact_pdf_mask = [1 if pdf == 'exact' else 0 for pdf in marginal_pdf]
 
@@ -754,10 +748,10 @@ def check_if_pdf_is_poisson(marginal_pdf: list) -> list:
     Check if each indicator's probability distribution function (PDF) is of type 'poisson'.
 
     Parameters:
-    - marginal_pdf (list): A list containing the type of PDF for each indicator.
+    - marginal_pdf: a list containing the type of PDF for each indicator.
 
     Returns:
-    - list: A binary mask indicating whether the PDF for each indicator is 'poisson' (1) or not (0).
+    - list: a binary mask indicating whether the PDF for each indicator is 'poisson' (1) or not (0).
 
     Example:
     ```python
@@ -765,8 +759,8 @@ def check_if_pdf_is_poisson(marginal_pdf: list) -> list:
     ```
     This will return a list [1, 0, 0, 0], indicating that the first indicator have a 'poisson' PDF.
 
-    :rtype: list
     :param marginal_pdf: list
+    :return poisson_pdf_mask: List[int]
     """
     poisson_pdf_mask = [1 if pdf == 'poisson' else 0 for pdf in marginal_pdf]
 
@@ -778,10 +772,10 @@ def check_if_pdf_is_uniform(marginal_pdf: list) -> list:
     Check if each indicator's probability distribution function (PDF) is of type 'uniform'.
 
     Parameters:
-    - marginal_pdf (list): A list containing the type of PDF for each indicator.
+    - marginal_pdf (list): a list containing the type of PDF for each indicator.
 
     Returns:
-    - list: A binary mask indicating whether the PDF for each indicator is 'uniform' (1) or not (0).
+    - list: a binary mask indicating whether the PDF for each indicator is 'uniform' (1) or not (0).
 
     Example:
     ```python
@@ -789,8 +783,8 @@ def check_if_pdf_is_uniform(marginal_pdf: list) -> list:
     ```
     This will return a list [0, 0, 0, 1], indicating that the fourth indicator have a 'uniform' PDF.
 
-    :rtype: list
     :param marginal_pdf: list
+    :return uniform_pdf_mask: List[int]
     """
     uniform_pdf_mask = [1 if pdf == 'uniform' else 0 for pdf in marginal_pdf]
 
@@ -810,12 +804,11 @@ def run_mcda_without_indicator_uncertainty(input_config: dict, index_column_name
     and logs the completion time.
 
     Parameters:
-    - input_matrix: The input_matrix without the alternatives.
+    - input_matrix: the input_matrix without the alternatives.
     - index_column_name: the name of the index column of the original input matrix.
     - index_column_values: the values of the index column of the original input matrix.
     - weights: the normalised weights (either fixed or random sampled weights, depending on the settings).
 
-    :return: None
     :param input_config: dict
     :param index_column_name: str
     :param index_column_values: list
@@ -824,7 +817,7 @@ def run_mcda_without_indicator_uncertainty(input_config: dict, index_column_name
     :param f_norm: str
     :param f_agg: str
     :param is_robustness_weights: int
-
+    :return: None
     """
     scores = pd.DataFrame()
     normalized_scores = pd.DataFrame()
@@ -885,7 +878,6 @@ def run_mcda_without_indicator_uncertainty(input_config: dict, index_column_name
                           is_robustness_weights=is_robustness_weights)
 
 
-
 def run_mcda_with_indicator_uncertainty(input_config: dict, input_matrix: pd.DataFrame,
                                         index_column_name: str, index_column_values: list,
                                         mc_runs: int, is_sensitivity: str, f_agg: str, f_norm: str,
@@ -898,13 +890,12 @@ def run_mcda_with_indicator_uncertainty(input_config: dict, input_matrix: pd.Dat
     It computes scores, saves the results, and logs the completion time.
 
     Parameters:
-    - input_matrix: The input_matrix without the alternatives.
+    - input_matrix: the input_matrix without the alternatives.
     - index_column_name: the name of the index column of the original input matrix.
     - index_column_values: the values of the index column of the original input matrix.
     - weights: the normalised weights (either fixed or random sampled weights, depending on the settings).
       In the context of the robustness analysis, only fixed normalised weights are used, i.e. weights[0].
 
-    :return: None
     :param input_config: dict
     :param index_column_name: str
     :param index_column_values: list
@@ -916,6 +907,7 @@ def run_mcda_with_indicator_uncertainty(input_config: dict, input_matrix: pd.Dat
     :param f_agg: str
     :param polar: List[str]
     :param marginal_pdf: List[str]
+    :return: None
     """
     logger.info("Start ProMCDA with uncertainty on the indicators")
     config = Config(input_config)

--- a/mcda/utils/utils_for_main.py
+++ b/mcda/utils/utils_for_main.py
@@ -302,7 +302,7 @@ def check_input_matrix(input_matrix: pd.DataFrame) -> pd.DataFrame:
     return input_matrix_no_alternatives
 
 
-def read_matrix(input_matrix_path: str) -> pd.DataFrame():
+def read_matrix(input_matrix_path: str) -> pd.DataFrame:
     """
     Read an input matrix from a CSV file and return it as a DataFrame.
     Set the 'Alternatives' column as index column.
@@ -348,7 +348,7 @@ def reset_index_if_needed(series):
     return series
 
 
-def _check_and_rescale_negative_indicators(input_matrix: pd.DataFrame) -> pd.DataFrame():
+def _check_and_rescale_negative_indicators(input_matrix: pd.DataFrame) -> pd.DataFrame:
     """
     Rescale indicators of the input matrix if negative into [0-1].
     """
@@ -500,7 +500,7 @@ def check_path_exists(path: str):
         print("The new output directory is created: {}".format(path))
 
 
-def rescale_minmax(scores: pd.DataFrame) -> pd.DataFrame():
+def rescale_minmax(scores: pd.DataFrame) -> pd.DataFrame:
     """
     Rescale the values in a DataFrame to a [0,1] range using Min-Max scaling.
 
@@ -522,8 +522,8 @@ def rescale_minmax(scores: pd.DataFrame) -> pd.DataFrame():
     1   0.5  0.5  0.5
     2   1.0  1.0  1.0
     ```
-    :param scores: pd.DataFrame()
-    :rtype: pd.DataFrame()
+    :param scores: pd.DataFrame
+    :rtype: pd.DataFrame
     """
     x = scores.to_numpy()
     min_max_scaler = preprocessing.MinMaxScaler()
@@ -819,11 +819,11 @@ def run_mcda_without_indicator_uncertainty(input_config: dict, index_column_name
     :param is_robustness_weights: int
     :return: None
     """
-    scores = pd.DataFrame()
-    normalized_scores = pd.DataFrame()
-    all_weights_score_means = pd.DataFrame()
-    all_weights_score_stds = pd.DataFrame()
-    all_weights_score_means_normalized = pd.DataFrame()
+    scores = pd.DataFrame
+    normalized_scores = pd.DataFrame
+    all_weights_score_means = pd.DataFrame
+    all_weights_score_stds = pd.DataFrame
+    all_weights_score_means_normalized = pd.DataFrame
     iterative_random_w_score_means_normalized = {}
     iterative_random_weights_statistics = {}
     iterative_random_w_score_means = {}
@@ -1073,7 +1073,7 @@ def _compute_ranks(scores: Optional[pd.DataFrame], index_column_name: str, index
     """
     Compute ranks based on the computed scores, mean scores with random weights, and mean scores for each random weight.
     """
-    ranks = pd.DataFrame()
+    ranks = pd.DataFrame
 
     if not scores.empty:
         ranks = scores.rank(pct=True)

--- a/mcda/utils/utils_for_parallelization.py
+++ b/mcda/utils/utils_for_parallelization.py
@@ -199,7 +199,7 @@ def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict, m
     scores_harmonic = {}
     scores_minimum = {}
 
-    scores = pd.DataFrame
+    scores = pd.DataFrame()
     col_names_method = []
     col_names = ['ws-minmax_01', 'ws-target_01', 'ws-standardized_any', 'ws-rank',
                  'geom-minmax_without_zero', 'geom-target_without_zero', 'geom-standardized_without_zero', 'geom-rank',

--- a/mcda/utils/utils_for_parallelization.py
+++ b/mcda/utils/utils_for_parallelization.py
@@ -42,9 +42,8 @@ def initialize_and_call_aggregation(args: Tuple[list, dict], method=None) -> pd.
 
     :param args: Tuple[list, dict]
     :param method: str
-    :return scores_one_run: pd.DataFrame()
+    :return scores_one_run: pd.DataFrame
     """
-
     weights, data = args
     agg = Aggregation(weights)
 
@@ -85,7 +84,7 @@ def initialize_and_call_normalization(args: Tuple[pd.DataFrame, list, str]) -> d
     normalization method to calculate normalized indicators. The resulting normalized indicators are returned
     as a dictionary.
 
-    :param args: Tuple[pd.DataFrame(), List[str], str]
+    :param args: Tuple[pd.DataFrame, List[str], str]
     :return dict_normalized_matrix: dict
     """
 
@@ -121,10 +120,9 @@ def normalize_indicators_in_parallel(norm: object, method=None) -> dict:
         used and values represent the corresponding normalized indicators.
 
         :param norm: object
-        :param method: string
+        :param method: str
         :return normalized_indicators: dict
         """
-
     indicators_scaled_standardized_any = None
     indicators_scaled_standardized_without_zero = None
     indicators_scaled_minmax_01 = None
@@ -167,7 +165,7 @@ def normalize_indicators_in_parallel(norm: object, method=None) -> dict:
     return normalized_indicators
 
 
-def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict, method=None) -> pd.DataFrame():
+def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict, method=None) -> pd.DataFrame:
     """
     Aggregate normalized indicators in parallel using different aggregation methods.
 
@@ -193,16 +191,15 @@ def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict, m
 
     :param agg: object
     :param normalized_indicators: dict
-    :param method: string
-    :return scores: pd.DataFrame()
+    :param method: str
+    :return scores: pd.DataFrame
     """
-
     scores_weighted_sum = {}
     scores_geometric = {}
     scores_harmonic = {}
     scores_minimum = {}
 
-    scores = pd.DataFrame()
+    scores = pd.DataFrame
     col_names_method = []
     col_names = ['ws-minmax_01', 'ws-target_01', 'ws-standardized_any', 'ws-rank',
                  'geom-minmax_without_zero', 'geom-target_without_zero', 'geom-standardized_without_zero', 'geom-rank',
@@ -284,11 +281,10 @@ def parallelize_normalization(input_matrices: List[pd.DataFrame], polar: list, m
     normalized indicators for each input matrix.
 
     :param input_matrices: List[pd.DataFrame]
-    :param polar: List[string]
-    :param method: string
+    :param polar: List[str]
+    :param method: str
     :return res: List[dict]
     """
-
     pool = multiprocessing.Pool()
     args_for_parallel_norm = [(df, polar, method) for df in input_matrices]
     res = pool.map(initialize_and_call_normalization, args_for_parallel_norm)
@@ -311,7 +307,6 @@ def estimate_runs_mean_std(res: List[pd.DataFrame]) -> List[pd.DataFrame]:
     :param res: List[pd.DataFrame]
     :return all_scores_mean_std: List[pd.DataFrame]
     """
-
     all_runs = pd.concat(res, axis=0)
     by_index = all_runs.groupby(all_runs.index)
     df_means = by_index.mean()

--- a/mcda/utils/utils_for_parallelization.py
+++ b/mcda/utils/utils_for_parallelization.py
@@ -13,6 +13,38 @@ logger = logging.getLogger("ProMCDA utils for parallelization")
 
 
 def initialize_and_call_aggregation(args: Tuple[list, dict], method=None) -> pd.DataFrame:
+    """
+    Initialize an Aggregation object with given weights and call the aggregation method to calculate scores.
+
+    Parameters:
+    - args: a tuple containing a list of weights and a dictionary of data.
+    - method (optional): the aggregation method to use. Defaults to None.
+
+    Returns:
+    - pd.DataFrame: DataFrame containing scores calculated using the aggregation method.
+
+    Example:
+    ```python
+    weights = [0.2, 0.3, 0.5]
+    data = {'indicator1': [10, 20, 30], 'indicator2': [40, 50, 60], 'indicator3': [70, 80, 90]}
+
+    scores = initialize_and_call_aggregation((weights, data), method='weighted_sum')
+
+    scores
+    0   32.0
+    1   50.0
+    2   77.0
+
+    ```
+
+    This example initializes an Aggregation object with the given weights and calls the specified aggregation method
+    to calculate scores using the provided data. The resulting scores are returned as a DataFrame.
+
+    :param args: Tuple[list, dict]
+    :param method: str
+    :return scores_one_run: pd.DataFrame()
+    """
+
     weights, data = args
     agg = Aggregation(weights)
 
@@ -21,7 +53,42 @@ def initialize_and_call_aggregation(args: Tuple[list, dict], method=None) -> pd.
     return scores_one_run
 
 
-def initialize_and_call_normalization(args: Tuple[pd.DataFrame, list, str]) -> List[dict]:
+def initialize_and_call_normalization(args: Tuple[pd.DataFrame, list, str]) -> dict:
+    """
+    Initialize a Normalization object with given matrix and polarities, and call the normalization method to
+    calculate normalized indicators.
+
+    Parameters:
+    - args: a tuple containing a DataFrame of indicators, a list of polarities,
+      and a string specifying the normalization method.
+
+    Returns:
+    - dict: a dictionary containing normalized indicators.
+
+    Example:
+    ```python
+    matrix = pd.DataFrame({'indicator1': [10, 20, 30], 'indicator2': [40, 50, 60]})
+    polarities = ['+', '-', '+']
+    method = 'minmax'
+
+    normalized_indicators = initialize_and_call_normalization((matrix, polarities, method))
+
+    normalized_indicators:
+    {
+    'indicator1': [0.0, 0.5, 1.0],
+    'indicator2': [0.0, 0.5, 1.0]
+     }
+
+    ```
+
+    This example initializes a Normalization object with the given matrix and polarities, and calls the specified
+    normalization method to calculate normalized indicators. The resulting normalized indicators are returned
+    as a dictionary.
+
+    :param args: Tuple[pd.DataFrame(), List[str], str]
+    :return dict_normalized_matrix: dict
+    """
+
     matrix, polarities, method = args
     norm = Normalization(matrix, polarities)
 
@@ -31,6 +98,33 @@ def initialize_and_call_normalization(args: Tuple[pd.DataFrame, list, str]) -> L
 
 
 def normalize_indicators_in_parallel(norm: object, method=None) -> dict:
+    """
+        Normalize indicators in parallel using different normalization methods.
+
+        Parameters:
+        - norm: an object representing the normalization process.
+        - method: the normalization method to use. Options are 'minmax', 'target', 'standardized', or 'rank'.
+
+        Returns:
+        - A dictionary containing the normalized indicators for each method.
+
+        Example:
+        ```python
+        norm = Normalization(matrix, polarities)
+        normalized_indicators = normalize_indicators_in_parallel(norm, method='minmax')
+
+        ```
+
+        This example normalizes indicators in parallel using the min-max normalization method.
+        Supported methods include 'minmax', 'target', 'standardized', and 'rank'.
+        The resulting normalized indicators are returned as a dictionary, where keys represent the normalization method
+        used and values represent the corresponding normalized indicators.
+
+        :param norm: object
+        :param method: string
+        :return normalized_indicators: dict
+        """
+
     indicators_scaled_standardized_any = None
     indicators_scaled_standardized_without_zero = None
     indicators_scaled_minmax_01 = None
@@ -74,6 +168,35 @@ def normalize_indicators_in_parallel(norm: object, method=None) -> dict:
 
 
 def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict, method=None) -> pd.DataFrame():
+    """
+    Aggregate normalized indicators in parallel using different aggregation methods.
+
+    Parameters:
+    - agg: an object representing the aggregation process.
+    - normalized_indicators: a dictionary containing the normalized indicators for each method.
+    - method: the aggregation method to use. Options are 'weighted_sum', 'geometric', 'harmonic', 'minimum', or None
+      (for all methods).
+
+    Returns:
+    - a DataFrame containing the aggregated scores for each method.
+
+    Example:
+    ```python
+    agg = Aggregation(weights)
+    aggregated_scores = aggregate_indicators_in_parallel(agg, normalized_indicators, method='weighted_sum')
+
+    ```
+
+    This example aggregates the normalized indicators in parallel using the weighted_sum method. The resulting
+    aggregated scores are returned as a DataFrame, where columns represent the aggregation method used and rows
+    represent the corresponding aggregated scores for each indicator.
+
+    :param agg: object
+    :param normalized_indicators: dict
+    :param method: string
+    :return scores: pd.DataFrame()
+    """
+
     scores_weighted_sum = {}
     scores_geometric = {}
     scores_harmonic = {}
@@ -134,7 +257,38 @@ def parallelize_aggregation(args: List[tuple], method=None) -> List[pd.DataFrame
 
 
 def parallelize_normalization(input_matrices: List[pd.DataFrame], polar: list, method=None) -> List[dict]:
-    # create a synchronous multiprocessing pool with the desired number of processes
+    """
+    Parallelize the normalization process for multiple input matrices using multiprocessing.
+
+    Parameters:
+    - input_matrices: a list of input matrices to be normalized.
+    - polar: a list containing the polarities for each input matrix.
+    - method: the normalization method to use. Options are 'minmax', 'target', 'standardized', 'rank', or None
+      (for all methods).
+
+    Returns:
+    - a list of dictionaries containing the normalized indicators for each input matrix.
+
+    Example:
+    ```python
+    input_matrices = [matrix1, matrix2, matrix3]
+    polar = ['+', '-', '+']
+
+    normalized_results = parallelize_normalization(input_matrices, polar, method='minmax')
+
+    ```
+
+    This example parallelizes the normalization process for multiple input matrices using multiprocessing.
+    It creates a synchronous multiprocessing pool with the desired number of processes and maps the initialization
+    and normalization calls across the input matrices. The function returns a list of dictionaries containing the
+    normalized indicators for each input matrix.
+
+    :param input_matrices: List[pd.DataFrame]
+    :param polar: List[string]
+    :param method: string
+    :return res: List[dict]
+    """
+
     pool = multiprocessing.Pool()
     args_for_parallel_norm = [(df, polar, method) for df in input_matrices]
     res = pool.map(initialize_and_call_normalization, args_for_parallel_norm)
@@ -146,9 +300,18 @@ def parallelize_normalization(input_matrices: List[pd.DataFrame], polar: list, m
 
 def estimate_runs_mean_std(res: List[pd.DataFrame]) -> List[pd.DataFrame]:
     """
+    Estimate the mean and standard deviation of scores from multiple runs.
 
-    :rtype: object
+    Parameters:
+    - res: a list of DataFrames containing scores from multiple runs.
+
+    Returns:
+    - a list containing two DataFrames: one for the mean scores and one for the standard deviations.
+
+    :param res: List[pd.DataFrame]
+    :return all_scores_mean_std: List[pd.DataFrame]
     """
+
     all_runs = pd.concat(res, axis=0)
     by_index = all_runs.groupby(all_runs.index)
     df_means = by_index.mean()

--- a/mcda/utils/utils_for_plotting.py
+++ b/mcda/utils/utils_for_plotting.py
@@ -10,6 +10,18 @@ from PIL import Image
 
 
 def plot_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
+    """
+    Plot the normalized scores without uncertainty as a histogram.
+
+    Parameters:
+    - scores: DataFrame containing the normalized scores.
+
+    Returns:
+    - Plotly figure object.
+
+    :param scores: pd.DataFrame
+    :return fig: object
+    """
     alternatives_column_name = scores.columns[0]
     num_of_combinations = scores.shape[1] - 1
     fig = go.Figure(layout_yaxis_range=[scores.iloc[:, 1:].values.min() - 0.5, scores.iloc[:, 1:].values.max() + 0.5],
@@ -42,6 +54,18 @@ def plot_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
 
 
 def plot_non_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
+    """
+        Plot the non-normalized scores without uncertainty as a histogram.
+
+        Parameters:
+        - scores: DataFrame containing the non-normalized scores.
+
+        Returns:
+        - Plotly figure object.
+
+        :param scores: pd.DataFrame
+        :return fig: object
+        """
     alternatives_column_name = scores.columns[0]
     num_of_combinations = scores.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA rough score")
@@ -71,6 +95,24 @@ def plot_non_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
 
 
 def plot_mean_scores(all_means: pd.DataFrame, plot_std: str, rand_on: str, all_stds=None) -> object:
+    """
+    Plot the mean scores with optional standard deviation as a histogram.
+
+    Parameters:
+    - all_means: DataFrame containing the mean scores.
+    - plot_std: string indicating whether to plot standard deviation or not.
+    - rand_on: string specifying the randomness added on which parameter for the title.
+    - all_stds (optional): DataFrame containing the standard deviations.
+
+    Returns:
+    - object: Plotly figure object.
+
+    :param all_means: pd.DataFrame
+    :parameter plot_std: str
+    :parameter rand_on: str
+    :param all_stds: pd.DataFrame
+    :return fig: object
+    """
     alternatives_column_name = all_means.columns[0]
     num_of_combinations = all_means.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA average scores and std")
@@ -113,6 +155,26 @@ def plot_mean_scores(all_means: pd.DataFrame, plot_std: str, rand_on: str, all_s
 
 def plot_mean_scores_iterative(all_weights_means: pd.DataFrame, indicators: list,
                                index: int, plot_std: str, all_weights_stds=None) -> object:
+    """
+    Plot the mean scores with optional standard deviation for iterative weight sampling as a histogram.
+
+    Parameters:
+    - all_weights_means: DataFrame containing the mean scores.
+    - indicators: list of indicator names.
+    - index : index of the indicator for which weights are sampled.
+    - plot_std: string indicating whether to plot standard deviation or not.
+    - all_weights_stds (optional): DataFrame containing the standard deviations.
+
+    Returns:
+    - object: Plotly figure object.
+
+    :param all_weights_means: pd.DataFrame
+    :parameter indicators: list
+    :parameter index: int
+    :parameter plot_std: str
+    :param all_weights_stds: pd.DataFrame
+    :return fig: object
+    """
     alternatives_column_name = all_weights_means.columns[0]
     num_of_combinations = all_weights_means.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA average scores and std")
@@ -151,6 +213,19 @@ def plot_mean_scores_iterative(all_weights_means: pd.DataFrame, indicators: list
 
 
 def save_figure(figure: object, folder_path: str, filename: str):
+    """
+    Save a Plotly figure as an image.
+
+    Parameters:
+    - figure: Plotly figure object to be saved.
+    - folder_path: path to the folder where the image will be saved.
+    - filename: name of the image file.
+
+    :param figure: object
+    :param folder_path: str
+    :param filename: str
+    :return: None
+    """
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     new_filename = f"{timestamp}_{filename}"
 
@@ -158,7 +233,20 @@ def save_figure(figure: object, folder_path: str, filename: str):
     figure.write_image(result_path)
 
 
-def combine_images(figures, folder_path: str, filename: str):
+def combine_images(figures: list, folder_path: str, filename: str):
+    """
+    Combine multiple Plotly figures into a single image.
+
+    Parameters:
+    - figures: list of Plotly figure objects to be combined.
+    - folder_path: path to the folder where the combined image will be saved.
+    - filename: name of the combined image file.
+
+    :param figures: list
+    :param folder_path: str
+    :param filename: str
+    :return: None
+    """
     images = []
     result_path = os.path.join(folder_path, filename)
     for fig in figures:

--- a/tests/unit_tests/test_mcda_run.py
+++ b/tests/unit_tests/test_mcda_run.py
@@ -1,14 +1,17 @@
 import unittest
 import logging
 import pytest
+import os
 
 from unittest.mock import patch
 
 from mcda.mcda_run import main
 
+tests_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # Get the tests root directory
+
 
 class TestMCDA(unittest.TestCase):
-    input_matrix_path = "tests/resources/input_matrix_with_uncert.csv"
+    input_matrix_path = os.path.join(tests_directory, "resources", "input_matrix_with_uncert.csv")
 
     @staticmethod
     def get_incorrect_config_1():


### PR DESCRIPTION
Add missing doctrings to non-private function and non-static methods (that receive only a brief description).
Some docstrings include a running example but not all.
Add minor refinements to fulfill consistency of adopted standards.