### PR TITLE
fix: robust column name handling when indicator names contain underscores

### DIFF
--- a/promcda/models/mcda_without_robustness.py
+++ b/promcda/models/mcda_without_robustness.py
@@ -14,6 +14,27 @@ from promcda.mcda_functions.aggregation import Aggregation
 
 log = logging.getLogger(__name__)
 
+# Maps each known normalized-column suffix to its base normalization method name.
+# Column names have the form '{indicator_name}_{suffix}'. Splitting on '_' and
+# taking a positional index breaks when indicator names themselves contain '_'.
+_NORM_SUFFIX_TO_METHOD = {
+    f"{NormalizationFunctions.MINMAX.value}_01": NormalizationFunctions.MINMAX.value,
+    f"{NormalizationFunctions.MINMAX.value}_without_zero": NormalizationFunctions.MINMAX.value,
+    f"{NormalizationFunctions.TARGET.value}_01": NormalizationFunctions.TARGET.value,
+    f"{NormalizationFunctions.TARGET.value}_without_zero": NormalizationFunctions.TARGET.value,
+    f"{NormalizationFunctions.STANDARDIZED.value}_any": NormalizationFunctions.STANDARDIZED.value,
+    f"{NormalizationFunctions.STANDARDIZED.value}_without_zero": NormalizationFunctions.STANDARDIZED.value,
+    NormalizationFunctions.RANK.value: NormalizationFunctions.RANK.value,
+}
+
+
+def _extract_norm_method(col_name: str):
+    """Return the normalization method for a normalized column name, or None if unrecognised."""
+    for suffix, method in _NORM_SUFFIX_TO_METHOD.items():
+        if col_name.endswith(f"_{suffix}"):
+            return method
+    return None
+
 formatter = '%(levelname)s: %(asctime)s - %(name)s - %(message)s'
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format=formatter)
 logger = logging.getLogger("ProMCDA aggregation")
@@ -147,7 +168,11 @@ class MCDAWithoutRobustness:
                     raise ValueError(f"Column name '{column_name}' not found in OutputColumnNames4Sensitivity")
                 score_list.append(aggregated_scores)
 
-        for norm_method in self.normalized_indicators.columns.str.split("_", n=0).str[1].unique():
+        norm_methods = list(dict.fromkeys(
+            m for col in self.normalized_indicators.columns
+            if (m := _extract_norm_method(col)) is not None
+        ))
+        for norm_method in norm_methods:
             score_list = []
 
             norm_method_columns = self.normalized_indicators.filter(regex=rf"{norm_method}")

--- a/promcda/models/mcda_without_robustness.py
+++ b/promcda/models/mcda_without_robustness.py
@@ -175,7 +175,7 @@ class MCDAWithoutRobustness:
         for norm_method in norm_methods:
             score_list = []
 
-            norm_method_columns = self.normalized_indicators.filter(regex=rf"{norm_method}")
+            norm_method_columns = self.normalized_indicators.filter(regex=rf"_{norm_method}(_|$)")
 
             without_zero_columns = norm_method_columns.filter(regex="without_zero$")
             with_zero_columns = norm_method_columns[norm_method_columns.columns.difference(without_zero_columns.columns)]

--- a/tests/unit_tests/test_mcda_without_robustness.py
+++ b/tests/unit_tests/test_mcda_without_robustness.py
@@ -226,5 +226,54 @@ class TestMCDA_without_robustness(unittest.TestCase):
         assert res[0].to_numpy().all() == TestMCDA_without_robustness.get_input_matrix().to_numpy().all()
         assert res[1].to_numpy().all() == df_std.to_numpy().all()
 
+    def test_normalize_indicators_with_underscores_in_column_names(self):
+        """Indicator names containing underscores must not break column suffix parsing."""
+        input_matrix = pd.DataFrame(
+            {
+                'alternative': ['A', 'B', 'C'],
+                'my_indicator_one': [1.0, 2.0, 3.0],
+                'my_indicator_two': [4.0, 5.0, 6.0],
+            }
+        ).set_index('alternative')
+        polarity = ('+', '+')
+
+        promcda = ProMCDA(input_matrix, polarity)
+        result = promcda.normalize(NormalizationFunctions.MINMAX)
+
+        assert isinstance(result, pd.DataFrame)
+        expected_suffixes = ['minmax_01', 'minmax_without_zero']
+        for suffix in expected_suffixes:
+            self.assertTrue(
+                any(col.endswith(suffix) for col in result.columns),
+                msg=f"No column ending with '{suffix}' found in {list(result.columns)}"
+            )
+
+    def test_normalize_indicators_with_multiple_consecutive_underscores(self):
+        """Indicator names with multiple underscores must produce correct column suffixes."""
+        input_matrix = pd.DataFrame(
+            {
+                'alternative': ['A', 'B', 'C'],
+                'ind_a_b_c': [1.0, 2.0, 3.0],
+                'ind_x_y_z': [4.0, 5.0, 6.0],
+            }
+        ).set_index('alternative')
+        polarity = ('+', '+')
+
+        promcda = ProMCDA(input_matrix, polarity)
+        result = promcda.normalize()
+
+        expected_suffixes = [
+            'minmax_01', 'minmax_without_zero',
+            'target_01', 'target_without_zero',
+            'standardized_any', 'standardized_without_zero',
+            'rank',
+        ]
+        for suffix in expected_suffixes:
+            self.assertTrue(
+                any(col.endswith(suffix) for col in result.columns),
+                msg=f"No column ending with '{suffix}' found — underscore in indicator name broke suffix detection"
+            )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests/test_mcda_without_robustness.py
+++ b/tests/unit_tests/test_mcda_without_robustness.py
@@ -289,6 +289,29 @@ class TestMCDA_without_robustness(unittest.TestCase):
                 msg=f"No column ending with '{suffix}' found in {list(result.columns)}"
             )
 
+    def test_aggregate_with_indicator_names_containing_norm_keywords(self):
+        """Indicator names that include normalization keywords (e.g. 'minmax_score')
+        must not confuse column filtering during aggregation."""
+        input_matrix = pd.DataFrame(
+            {
+                'alternative': ['A', 'B', 'C'],
+                'minmax_score': [1.0, 2.0, 3.0],
+                'target_value': [4.0, 5.0, 6.0],
+            }
+        ).set_index('alternative')
+        polarity = ('+', '+')
+        weights = [0.5, 0.5]
+
+        promcda = ProMCDA(input_matrix, polarity, weights)
+        promcda.normalize(NormalizationFunctions.MINMAX)
+        result = promcda.aggregate(AggregationFunctions.WEIGHTED_SUM)
+
+        assert isinstance(result, pd.DataFrame)
+        self.assertIn('ws-minmax_01', result.columns.tolist())
+        self.assertEqual(result.shape[0], input_matrix.shape[0])
+        # Ensure exactly the expected columns and no duplicates
+        self.assertEqual(len(result.columns), 1)
+
     def test_normalize_indicators_with_multiple_consecutive_underscores(self):
         """Indicator names with multiple underscores must produce correct column suffixes."""
         input_matrix = pd.DataFrame(

--- a/tests/unit_tests/test_mcda_without_robustness.py
+++ b/tests/unit_tests/test_mcda_without_robustness.py
@@ -226,6 +226,47 @@ class TestMCDA_without_robustness(unittest.TestCase):
         assert res[0].to_numpy().all() == TestMCDA_without_robustness.get_input_matrix().to_numpy().all()
         assert res[1].to_numpy().all() == df_std.to_numpy().all()
 
+    def test_aggregate_indicators_with_underscores_in_column_names(self):
+        """Aggregation must work correctly when indicator names contain underscores."""
+        input_matrix = pd.DataFrame(
+            {
+                'alternative': ['A', 'B', 'C'],
+                'my_indicator_one': [1.0, 2.0, 3.0],
+                'my_indicator_two': [4.0, 5.0, 6.0],
+            }
+        ).set_index('alternative')
+        polarity = ('+', '+')
+        weights = [0.5, 0.5]
+
+        promcda = ProMCDA(input_matrix, polarity, weights)
+        promcda.normalize(NormalizationFunctions.MINMAX)
+        result = promcda.aggregate(AggregationFunctions.WEIGHTED_SUM)
+
+        assert isinstance(result, pd.DataFrame)
+        self.assertIn('ws-minmax_01', result.columns.tolist())
+        self.assertEqual(result.shape[0], input_matrix.shape[0])
+
+    def test_aggregate_all_methods_with_underscores_in_column_names(self):
+        """Full sensitivity run (all norm + agg methods) must succeed with underscored names."""
+        input_matrix = pd.DataFrame(
+            {
+                'alternative': ['A', 'B', 'C'],
+                'ind_a_b': [1.0, 2.0, 3.0],
+                'ind_c_d': [4.0, 5.0, 6.0],
+            }
+        ).set_index('alternative')
+        polarity = ('+', '+')
+        weights = [0.5, 0.5]
+
+        promcda = ProMCDA(input_matrix, polarity, weights)
+        promcda.normalize()
+        result = promcda.aggregate()
+
+        expected_columns = [e.value for e in OutputColumnNames4Sensitivity]
+        assert isinstance(result, pd.DataFrame)
+        self.assertListEqual(result.columns.tolist(), expected_columns)
+        self.assertEqual(result.shape[0], input_matrix.shape[0])
+
     def test_normalize_indicators_with_underscores_in_column_names(self):
         """Indicator names containing underscores must not break column suffix parsing."""
         input_matrix = pd.DataFrame(


### PR DESCRIPTION
## Summary

Fixes #66 - indicator names containing underscores caused incorrect normalization method extraction and wrong column filtering during aggregation.

### Root cause

In aggregate_indicators(), normalized column names were parsed with a positional split on underscore, taking the second element. For a plain indicator name like indicator1 the column indicator1_minmax_01 gives the correct result minmax. But for my_indicator_minmax_01 (indicator named my_indicator) it gives indicator, which matches nothing in NormalizationFunctions and silently skips aggregation for that method.

A second problem: the column filter regex was unanchored, so an indicator named minmax_score would cause its columns to be included in the wrong normalization subset.

### Fix

- Introduce _NORM_SUFFIX_TO_METHOD and _extract_norm_method() that match the known suffix at the end of each column name, robust regardless of underscores in the indicator name.
- Anchor the column filter regex to suffix position.

### Tests

Five new test cases in test_mcda_without_robustness.py:
- normalization with underscored indicator names
- normalization with multiple consecutive underscores
- aggregation (single method) with underscored indicator names
- full sensitivity run with underscored indicator names
- edge case: indicator names containing normalization keywords (e.g. minmax_score)

## Test plan

- [ ] python3 -m pytest -s tests/unit_tests/test_mcda_without_robustness.py -vv
- [ ] Full test suite: python3 -m pytest -s tests/unit_tests -vv
- [ ] Manual: CSV with underscore column names, run full MCDA analysis

## Contributors

Contributed by **The Wroclaw Institute of Spatial Information and Artificial Intelligence (WIZIPISI - Wroclawski Instytut Zastosowan Informacji Przestrzennej i Sztucznej Inteligencji)** - adam.nadolny@wizipisi.ai